### PR TITLE
Add script for spleen rRNA contamination box plots

### DIFF
--- a/Manuscript_Code/NBISC100_project/spleen/rRNA_contamination/Spleen_rRNA_contamination_mobashar
+++ b/Manuscript_Code/NBISC100_project/spleen/rRNA_contamination/Spleen_rRNA_contamination_mobashar
@@ -1,0 +1,54 @@
+#load library
+library(ggplot2)
+library(tidyverse)
+library(scales)
+library(RColorBrewer)
+
+#load data
+spleen.metrics.df <- read_csv("spleen_FLT_GC_qc_metrics.csv")
+
+# prepare data for rRNA contamination
+rRNA_contamination.spleen.metrics.df <-spleen.metrics.df %>%
+  select(osd_num, rrna_contamination)
+
+# Add a new column for library kit
+rRNA_contamination.spleen.metrics.df <- rRNA_contamination.spleen.metrics.df %>% 
+  mutate(library_kit= recode(osd_num,
+                             "OSD-164"="polyA-nonUPX kit",
+                             "OSD-246"="ribo-deplete kit",
+                             "OSD-288"="ribo-deplete kit",
+                             "OSD-420"="polyA-UPX kit",
+                             "OSD-457"="polyA-nonUPX kit",
+                             "OSD-506"="ribo-deplete kit"))
+
+# Box_plot1: spleen_rRNA_contamination_individual_datasets
+
+ggplot(rRNA_contamination.spleen.metrics.df, aes(x = osd_num, y = rrna_contamination, fill = osd_num)) +
+  geom_boxplot(size = 0.1, varwidth = TRUE) +
+  stat_boxplot(geom = "errorbar", width = 0.2, size= 0.1)+
+  scale_y_continuous(breaks = pretty_breaks(n = 10))+ 
+  scale_fill_brewer(palette = "Set2")+
+  labs(title = "rRNA Contamination of Individual Spleen Datasets", x = "OSD-number", y = "rRNA contamination %") +
+  theme_classic() +
+  theme(legend.position = "none")+
+  theme(plot.title = element_text(hjust = 0.5))
+
+ggsave("rRNA_contamination1_spleen_indivisual_datasets_MA.png", dpi = 300,
+       width = 6.7, height = 4, units = "in")
+
+
+# Box_plot2: spleen_rRNA_contamination by library kit
+ggplot(rRNA_contamination.spleen.metrics.df, aes(x = osd_num, y = rrna_contamination, fill= osd_num)) +
+  geom_boxplot(size = 0.1, varwidth = TRUE) +
+  stat_boxplot(geom = "errorbar", width = 0.2, size= 0.1)+
+  facet_wrap(~library_kit, scales = "free_x", drop = TRUE)+
+  scale_y_continuous(breaks = pretty_breaks(n = 10))+ 
+  scale_fill_brewer(palette = "Set2") +
+  labs(title = "rRNA Contamination of Spleen Datasets by Library Kits", x = "OSD-number", y = "rRNA contamination %") +
+  theme_classic() +
+  theme(legend.position = "none")+
+  theme(plot.title = element_text(hjust = 0.5))
+
+ggsave("rRNA_contamination_spleen_libraryKits_MA.png", dpi = 300,
+       width = 6.7, height = 4, units = "in")
+


### PR DESCRIPTION
This script generates box plots to visualize rRNA contamination in spleen datasets, both individually and by library kit type.